### PR TITLE
React develop #2

### DIFF
--- a/note-app/src/App.js
+++ b/note-app/src/App.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import MyNotes from './pages/MyNotes/MyNotes';
 
 function App() {

--- a/note-app/src/components/DisplayedNote/DisplayedNote.jsx
+++ b/note-app/src/components/DisplayedNote/DisplayedNote.jsx
@@ -3,57 +3,19 @@ import PropTypes from 'prop-types';
 import EditIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
 import Button from '@material-ui/core/Button';
-import { Input } from 'antd';
 
 import { styles } from './styles';
 
-const DisplayedNote = ({ activeNote, onEdited, setEditing }) => {
-  const descOutputNode = React.createRef();
-  const titleOutputNode = React.createRef();
-  const changeNoteForm = React.createRef();
-  const noteMenu = React.createRef();
-
-  const [titleValue, setTitleValue] = React.useState('');
-  const [descValue, setDescValue] = React.useState('');
-
+const DisplayedNote = ({ activeNote, isEditing, setEditing }) => {
   const onEditClick = (event) => {
-    setTitleValue(activeNote.title);
-    setDescValue(activeNote.description);
     setEditing(true);
-    revertDisplay();
   };
-
-  const onApplyChanges = (event) => {
-    activeNote.title = titleValue;
-    activeNote.description = descValue;
-    if (onEdited) {
-      onEdited();
-    }
-    setEditing(false);
-    revertDisplay();
-    event.preventDefault();
-  };
-
-  const onCanceled = (event) => {
-    revertDisplay();
-    setEditing(false);
-  };
-
-  const revertDisplay = () => {
-    titleOutputNode.current.style.display = getRevertedDisplay(titleOutputNode);
-    descOutputNode.current.style.display = getRevertedDisplay(descOutputNode);
-    changeNoteForm.current.style.display = getRevertedDisplay(changeNoteForm);
-    noteMenu.current.style.display = getRevertedDisplay(noteMenu);
-  };
-
-  const getRevertedDisplay = (refered) =>
-    refered.current.style.display === 'none' ? 'block' : 'none';
 
   return (
-    <div style={styles.wrapper}>
+    <div style={{ ...styles.wrapper, display: isEditing ? 'none' : 'block' }}>
       {activeNote ? (
         <div>
-          <div style={styles.noteMenu} ref={noteMenu}>
+          <div style={styles.noteMenu}>
             <Button style={styles.menuButton}>
               <DeleteIcon />
             </Button>
@@ -61,36 +23,8 @@ const DisplayedNote = ({ activeNote, onEdited, setEditing }) => {
               <EditIcon />
             </Button>
           </div>
-          <p style={styles.noteTitle} ref={titleOutputNode}>
-            {activeNote.title}
-          </p>
-          <p style={styles.noteDescription} ref={descOutputNode}>
-            {activeNote.description}
-          </p>
-          <form
-            ref={changeNoteForm}
-            style={styles.editPanel}
-            onSubmit={onApplyChanges}
-          >
-            <Input
-              style={styles.noteInput}
-              name="title"
-              value={titleValue}
-              onChange={(e) => setTitleValue(e.target.value)}
-            />
-            <Input
-              style={styles.noteInput}
-              name="desc"
-              value={descValue}
-              onChange={(e) => setDescValue(e.target.value)}
-            />
-            <Button type="submit" style={styles.applyButton}>
-              Apply
-            </Button>
-            <Button style={styles.applyButton} onClick={onCanceled}>
-              Cancel
-            </Button>
-          </form>
+          <p style={styles.noteTitle}>{activeNote.title}</p>
+          <p style={styles.noteDescription}>{activeNote.description}</p>
           <p style={styles.noteCreation}>{activeNote.creation}</p>
         </div>
       ) : (
@@ -102,8 +36,8 @@ const DisplayedNote = ({ activeNote, onEdited, setEditing }) => {
 
 DisplayedNote.propTypes = {
   activeNote: PropTypes.object,
-  onEdited: PropTypes.func,
-  setEditing: PropTypes.func,
+  isEditing: PropTypes.bool.isRequired,
+  setEditing: PropTypes.func.isRequired,
 };
 
 export default DisplayedNote;

--- a/note-app/src/components/DisplayedNote/DisplayedNote.jsx
+++ b/note-app/src/components/DisplayedNote/DisplayedNote.jsx
@@ -1,22 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Styles } from './styles'
 
-function DisplayedNote({ activeNote }) {
-  return (
-    <div style={Styles.wrapper}>
-      {activeNote === null ? (
-        <p style={Styles.noNoteMessage}>Select note to display</p>
-      ) : (
-        <div>
-          <p style={Styles.noteTitle}>{activeNote.title}</p>
-          <p style={Styles.noteDescription}>{activeNote.description}</p>
-          <p style={Styles.noteCreation}>{activeNote.creation}</p>
-        </div>
-      )}
-    </div>
-  );
-}
+import { styles } from './styles';
+
+const DisplayedNote = ({ activeNote }) => (
+  <div style={styles.wrapper}>
+    {!activeNote ? (
+      <p style={styles.noNoteMessage}>Select note to display</p>
+    ) : (
+      <div>
+        <p style={styles.noteTitle}>{activeNote.title}</p>
+        <p style={styles.noteDescription}>{activeNote.description}</p>
+        <p style={styles.noteCreation}>{activeNote.creation}</p>
+      </div>
+    )}
+  </div>
+);
 
 DisplayedNote.propTypes = {
   activeNote: PropTypes.object.isRequired,

--- a/note-app/src/components/DisplayedNote/DisplayedNote.jsx
+++ b/note-app/src/components/DisplayedNote/DisplayedNote.jsx
@@ -5,14 +5,14 @@ import { styles } from './styles';
 
 const DisplayedNote = ({ activeNote }) => (
   <div style={styles.wrapper}>
-    {!activeNote ? (
-      <p style={styles.noNoteMessage}>Select note to display</p>
-    ) : (
+    {activeNote ? (
       <div>
         <p style={styles.noteTitle}>{activeNote.title}</p>
         <p style={styles.noteDescription}>{activeNote.description}</p>
         <p style={styles.noteCreation}>{activeNote.creation}</p>
       </div>
+    ) : (
+      <p style={styles.noNoteMessage}>Select note to display</p>
     )}
   </div>
 );

--- a/note-app/src/components/DisplayedNote/styles.js
+++ b/note-app/src/components/DisplayedNote/styles.js
@@ -1,4 +1,4 @@
-export const Styles = {
+export const styles = {
   wrapper: {
     boxShadow: '#609BEB 0 0 7px 2px',
     margin: '20px',

--- a/note-app/src/components/DisplayedNote/styles.js
+++ b/note-app/src/components/DisplayedNote/styles.js
@@ -36,25 +36,4 @@ export const styles = {
     minWidth: 0,
     margin: '0 5px',
   },
-
-  noteInput: {
-    color: 'rgb(255,255,255,0.6)',
-    backgroundColor: 'transparent',
-    fontSize: '18px',
-    border: 'solid 1px #609BEB',
-    padding: '10px',
-    display: 'block',
-    marginTop: '20px',
-    width: '40vw',
-  },
-
-  applyButton: {
-    color: '#609BEB',
-    backgroundColor: 'transparent',
-    marginTop: '20px',
-  },
-
-  editPanel: {
-    display: 'none',
-  },
 };

--- a/note-app/src/components/EditNotePanel/EditNotePanel.jsx
+++ b/note-app/src/components/EditNotePanel/EditNotePanel.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '@material-ui/core';
+import { Input } from 'antd';
+
+import { styles } from './styles';
+
+const EditNotePanel = ({ onEdited, activeNote, onCanceled }) => {
+  const [titleValue, setTitleValue] = React.useState('');
+  const [descValue, setDescValue] = React.useState('');
+
+  React.useEffect(() => {
+    setTitleValue(activeNote ? activeNote.title : '');
+    setDescValue(activeNote ? activeNote.description : '');
+  }, [activeNote]);
+
+  const onApplyChanges = (event) => {
+    event.preventDefault();
+
+    activeNote.title = titleValue;
+    activeNote.description = descValue;
+
+    if (onEdited) {
+      onEdited();
+    }
+  };
+  const onCancelClick = (event) => {
+    if (onCanceled) {
+      onCanceled();
+    }
+  };
+
+  return (
+    <form onSubmit={onApplyChanges}>
+      <Input
+        style={styles.noteInput}
+        name="title"
+        value={titleValue}
+        onChange={(e) => setTitleValue(e.target.value)}
+      />
+      <Input
+        style={styles.noteInput}
+        name="desc"
+        value={descValue}
+        onChange={(e) => setDescValue(e.target.value)}
+      />
+      <Button type="submit" style={styles.applyButton}>
+        Apply
+      </Button>
+      <Button style={styles.applyButton} onClick={onCancelClick}>
+        Cancel
+      </Button>
+    </form>
+  );
+};
+
+EditNotePanel.propTypes = {
+  onEdited: PropTypes.func,
+  activeNote: PropTypes.object,
+  onCanceled: PropTypes.func,
+};
+
+export default EditNotePanel;

--- a/note-app/src/components/EditNotePanel/EditNotePanel.jsx
+++ b/note-app/src/components/EditNotePanel/EditNotePanel.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@material-ui/core';
 import { Input } from 'antd';
@@ -6,10 +6,10 @@ import { Input } from 'antd';
 import { styles } from './styles';
 
 const EditNotePanel = ({ onEdited, activeNote, onCanceled }) => {
-  const [titleValue, setTitleValue] = React.useState('');
-  const [descValue, setDescValue] = React.useState('');
+  const [titleValue, setTitleValue] = useState('');
+  const [descValue, setDescValue] = useState('');
 
-  React.useEffect(() => {
+  useEffect(() => {
     setTitleValue(activeNote ? activeNote.title : '');
     setDescValue(activeNote ? activeNote.description : '');
   }, [activeNote]);
@@ -20,14 +20,10 @@ const EditNotePanel = ({ onEdited, activeNote, onCanceled }) => {
     activeNote.title = titleValue;
     activeNote.description = descValue;
 
-    if (onEdited) {
-      onEdited();
-    }
+    onEdited();
   };
   const onCancelClick = (event) => {
-    if (onCanceled) {
-      onCanceled();
-    }
+    onCanceled();
   };
 
   return (
@@ -55,9 +51,9 @@ const EditNotePanel = ({ onEdited, activeNote, onCanceled }) => {
 };
 
 EditNotePanel.propTypes = {
-  onEdited: PropTypes.func,
+  onEdited: PropTypes.func.isRequired,
   activeNote: PropTypes.object,
-  onCanceled: PropTypes.func,
+  onCanceled: PropTypes.func.isRequired,
 };
 
 export default EditNotePanel;

--- a/note-app/src/components/EditNotePanel/styles.js
+++ b/note-app/src/components/EditNotePanel/styles.js
@@ -1,0 +1,18 @@
+export const styles = {
+  noteInput: {
+    color: 'rgb(255,255,255,0.6)',
+    backgroundColor: 'transparent',
+    fontSize: '18px',
+    border: 'solid 1px #609BEB',
+    padding: '10px',
+    display: 'block',
+    marginTop: '20px',
+    width: '40vw',
+  },
+
+  applyButton: {
+    color: '#609BEB',
+    backgroundColor: 'transparent',
+    marginTop: '20px',
+  },
+};

--- a/note-app/src/components/NoteList/NoteItem/NoteItem.jsx
+++ b/note-app/src/components/NoteList/NoteItem/NoteItem.jsx
@@ -1,38 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Styles } from './styles';
 import { Button } from '@material-ui/core';
 
-function NoteItem({ note, onSelect }) {
-  let totalWrapperStyle;
+import getNoteDescription from '../../../utils/getNoteDescription';
+import { styles } from './styles';
 
-  if (note.isActive) {
-    totalWrapperStyle = { ...Styles.itemWrapper, ...Styles.itemWrapper_active };
-  } else {
-    totalWrapperStyle = { ...Styles.itemWrapper };
-  }
+const NoteItem = ({ note, onSelect, isActive }) => {
+  const wrapperStyle = {
+    ...styles.itemWrapper,
+    ...(isActive && { ...styles.itemWrapper_active }),
+  };
 
   return (
-    <div style={totalWrapperStyle} onClick={onSelect.bind(null, note)}>
-      <div style={Styles.itemContent}>
-        <p style={Styles.itemTitle}>{note.title}</p>
-        <p>
-          {note.description.length < 20
-            ? note.description
-            : note.description.substring(0, 20) + '...'}
-        </p>
-        <p>
-          {note.creation}
-        </p>
+    <div style={wrapperStyle} onClick={onSelect.bind(null, note)}>
+      <div style={styles.itemContent}>
+        <p style={styles.itemTitle}>{note.title}</p>
+        <p>{getNoteDescription(note)}</p>
+        <p>{note.creation}</p>
       </div>
-      <Button style={Styles.closeButton}>&#10008;</Button>
+      <Button style={styles.closeButton}>&#10008;</Button>
     </div>
   );
-}
+};
 
 NoteItem.propTypes = {
   note: PropTypes.object.isRequired,
   onSelect: PropTypes.func,
+  isActive: PropTypes.bool,
 };
 
 export default NoteItem;

--- a/note-app/src/components/NoteList/NoteItem/styles.js
+++ b/note-app/src/components/NoteList/NoteItem/styles.js
@@ -1,4 +1,4 @@
-export const Styles = {
+export const styles = {
   itemWrapper: {
     backgroundColor: '#333333',
     color: '#609BEB',

--- a/note-app/src/components/NoteList/NoteList.jsx
+++ b/note-app/src/components/NoteList/NoteList.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import NoteItem from './NoteItem/NoteItem';
 
-const NoteList = ({ style, notes, onSelect, activeNote, disabled }) => (
+const NoteList = ({ style, notes, onSelect, activeNote }) => (
   <div style={style}>
     {notes.map((note, index) => (
       <NoteItem note={note} key={index} onSelect={onSelect} isActive={activeNote && activeNote.id === note.id}/>
@@ -16,7 +16,6 @@ NoteList.propTypes = {
   notes: PropTypes.arrayOf(PropTypes.object).isRequired,
   onSelect: PropTypes.func.isRequired,
   activeNote: PropTypes.object,
-  disabled: PropTypes.bool,
 };
 
 export default NoteList;

--- a/note-app/src/components/NoteList/NoteList.jsx
+++ b/note-app/src/components/NoteList/NoteList.jsx
@@ -1,21 +1,21 @@
 import React from 'react';
-import NoteItem from './NoteItem/NoteItem';
-import PropTypes from 'prop-types'
+import PropTypes from 'prop-types';
 
-function NoteList({ style, notes, onSelect }) {
-  return (
-    <div style={style}>
-      {notes.map((note, index) => {
-        return <NoteItem note={note} key={index} onSelect={onSelect}></NoteItem>;
-      })}
-    </div>
-  );
-}
+import NoteItem from './NoteItem/NoteItem';
+
+const NoteList = ({ style, notes, onSelect, activeNote }) => (
+  <div style={style}>
+    {notes.map((note, index) => (
+      <NoteItem note={note} key={index} onSelect={onSelect} isActive={activeNote && activeNote.id === note.id} />
+    ))}
+  </div>
+);
 
 NoteList.propTypes = {
   style: PropTypes.object.isRequired,
   notes: PropTypes.arrayOf(PropTypes.object).isRequired,
   onSelect: PropTypes.func.isRequired,
-}
+  activeNote: PropTypes.object.isRequired,
+};
 
 export default NoteList;

--- a/note-app/src/components/NoteList/styles.js
+++ b/note-app/src/components/NoteList/styles.js
@@ -1,3 +1,3 @@
-export const Styles = {
+export const styles = {
     
 };

--- a/note-app/src/config/constants/index.js
+++ b/note-app/src/config/constants/index.js
@@ -21,3 +21,5 @@ export const NOTES = [
     creation: new Date().toDateString(),
   },
 ];
+
+export const STORAGE_NOTES_CELL = 'noteList';

--- a/note-app/src/config/constants/index.js
+++ b/note-app/src/config/constants/index.js
@@ -1,0 +1,23 @@
+export const MAX_DESCRIPTION_LENGTH = 20;
+
+export const NOTES = [
+  {
+    id: 1,
+    title: 'Finish task 1 React',
+    description:
+      'React is sooooooooooooooooooooooooooooo cooooooooooooooooooool!!!',
+    creation: new Date('July 7, 2021 15:45:00').toDateString(),
+  },
+  {
+    id: 2,
+    title: 'Have a lunch',
+    description: 'Some meat balls are waiting for me..',
+    creation: new Date('July 7, 2021 16:00:00').toDateString(),
+  },
+  {
+    id: 3,
+    title: 'Just an empty note',
+    description: 'Almost empty',
+    creation: new Date().toDateString(),
+  },
+];

--- a/note-app/src/config/constants/maxDescriptionLength.js
+++ b/note-app/src/config/constants/maxDescriptionLength.js
@@ -1,0 +1,3 @@
+const MAX_DESCRIPTION_LENGTH = 20;
+
+export default MAX_DESCRIPTION_LENGTH;

--- a/note-app/src/config/constants/maxDescriptionLength.js
+++ b/note-app/src/config/constants/maxDescriptionLength.js
@@ -1,3 +1,0 @@
-const MAX_DESCRIPTION_LENGTH = 20;
-
-export default MAX_DESCRIPTION_LENGTH;

--- a/note-app/src/pages/myNotes/myNotes.jsx
+++ b/note-app/src/pages/myNotes/myNotes.jsx
@@ -3,30 +3,9 @@ import React from 'react';
 import NoteList from '../../components/NoteList/NoteList';
 import DisplayedNote from '../../components/DisplayedNote/DisplayedNote';
 import { styles } from './styles';
+import { NOTES } from '../../config/constants';
 
 const MyNotes = () => {
-  const NOTES = [
-    {
-      id: 1,
-      title: 'Finish task 1 React',
-      description:
-        'React is sooooooooooooooooooooooooooooo cooooooooooooooooooool!!!',
-      creation: new Date('July 7, 2021 15:45:00').toDateString(),
-    },
-    {
-      id: 2,
-      title: 'Have a lunch',
-      description: 'Some meat balls are waiting for me..',
-      creation: new Date('July 7, 2021 16:00:00').toDateString(),
-    },
-    {
-      id: 3,
-      title: 'Just an empty note',
-      description: 'Almost empty',
-      creation: new Date().toDateString(),
-    },
-  ];
-
   const [noteList, setNoteList] = React.useState(NOTES);
   const [activeNote, setActiveNote] = React.useState(null);
 

--- a/note-app/src/pages/myNotes/myNotes.jsx
+++ b/note-app/src/pages/myNotes/myNotes.jsx
@@ -4,6 +4,7 @@ import NoteList from '../../components/NoteList/NoteList';
 import DisplayedNote from '../../components/DisplayedNote/DisplayedNote';
 import { styles } from './styles';
 import { NOTES } from '../../config/constants';
+import EditNotePanel from '../../components/EditNotePanel/EditNotePanel';
 
 const MyNotes = () => {
   const [noteList, setNoteList] = React.useState(
@@ -21,8 +22,13 @@ const MyNotes = () => {
     localStorage.setItem('noteList', JSON.stringify(notes));
 
   const onEdited = () => {
+    setEditMode(false);
     setNoteList(noteList);
     saveNotesLocal(noteList);
+  };
+
+  const onCanceled = () => {
+    setEditMode(false);
   };
 
   return (
@@ -38,9 +44,21 @@ const MyNotes = () => {
       <div style={styles.sideInfoDisplay}>
         <DisplayedNote
           activeNote={activeNote}
-          onEdited={onEdited}
+          isEditing={isEditOn}
           setEditing={setEditMode}
         />
+        <div
+          style={{
+            ...styles.editPanelWrapper,
+            display: isEditOn ? 'block' : 'none',
+          }}
+        >
+          <EditNotePanel
+            onEdited={onEdited}
+            activeNote={activeNote}
+            onCanceled={onCanceled}
+          />
+        </div>
       </div>
     </div>
   );

--- a/note-app/src/pages/myNotes/myNotes.jsx
+++ b/note-app/src/pages/myNotes/myNotes.jsx
@@ -1,25 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import NoteList from '../../components/NoteList/NoteList';
 import DisplayedNote from '../../components/DisplayedNote/DisplayedNote';
 import { styles } from './styles';
-import { NOTES } from '../../config/constants';
+import { NOTES, STORAGE_NOTES_CELL } from '../../config/constants';
 import EditNotePanel from '../../components/EditNotePanel/EditNotePanel';
 
 const MyNotes = () => {
-  const [noteList, setNoteList] = React.useState(
-    JSON.parse(localStorage.getItem('noteList'))
-      ? JSON.parse(localStorage.getItem('noteList'))
+  const [noteList, setNoteList] = useState(
+    JSON.parse(localStorage.getItem(STORAGE_NOTES_CELL))
+      ? JSON.parse(localStorage.getItem(STORAGE_NOTES_CELL))
       : NOTES
   );
-  const [activeNote, setActiveNote] = React.useState(null);
-  const [isEditOn, setEditMode] = React.useState(false);
+  const [activeNote, setActiveNote] = useState(null);
+  const [isEditOn, setEditMode] = useState(false);
 
   const onSelectNote = (selectedNote) =>
     isEditOn ? null : setActiveNote(selectedNote);
 
   const saveNotesLocal = (notes) =>
-    localStorage.setItem('noteList', JSON.stringify(notes));
+    localStorage.setItem(STORAGE_NOTES_CELL, JSON.stringify(notes));
 
   const onEdited = () => {
     setEditMode(false);

--- a/note-app/src/pages/myNotes/myNotes.jsx
+++ b/note-app/src/pages/myNotes/myNotes.jsx
@@ -1,62 +1,52 @@
 import React from 'react';
+
 import NoteList from '../../components/NoteList/NoteList';
 import DisplayedNote from '../../components/DisplayedNote/DisplayedNote';
-import { Styles } from './styles';
+import { styles } from './styles';
 
-function MyNotes() {
-  const notes = [
+const MyNotes = () => {
+  const NOTES = [
     {
+      id: 1,
       title: 'Finish task 1 React',
       description:
         'React is sooooooooooooooooooooooooooooo cooooooooooooooooooool!!!',
       creation: new Date('July 7, 2021 15:45:00').toDateString(),
-      isActive: false,
     },
     {
+      id: 2,
       title: 'Have a lunch',
       description: 'Some meat balls are waiting for me..',
       creation: new Date('July 7, 2021 16:00:00').toDateString(),
-      isActive: false,
     },
     {
+      id: 3,
       title: 'Just an empty note',
       description: 'Almost empty',
       creation: new Date().toDateString(),
-      isActive: false,
     },
   ];
 
-  const [noteList, setNoteList] = React.useState(notes);
+  const [noteList, setNoteList] = React.useState(NOTES);
   const [activeNote, setActiveNote] = React.useState(null);
 
-  function onSelectNote(selectedNote) {
-    setNoteList(
-      noteList.map((note) => {
-        if (note === selectedNote) {
-          note.isActive = true;
-          setActiveNote(selectedNote);
-        } else {
-          note.isActive = false;
-        }
-        return note;
-      })
-    );
-  }
+  const onSelectNote = (selectedNote) => setActiveNote(selectedNote);
 
   return (
-    <div style={Styles.pageBody}>
-      <div style={Styles.sideNotePanel}>
+    <div style={styles.pageBody}>
+      <div style={styles.sideNotePanel}>
         <NoteList
-          style={Styles.noteList}
+          style={styles.noteList}
           notes={noteList}
           onSelect={onSelectNote}
-        ></NoteList>
+          activeNote={activeNote}
+        />
       </div>
-      <div style={Styles.sideInfoDisplay}>
-        <DisplayedNote activeNote={activeNote}></DisplayedNote>
+      <div style={styles.sideInfoDisplay}>
+        <DisplayedNote activeNote={activeNote} />
       </div>
     </div>
   );
-}
+};
 
 export default MyNotes;

--- a/note-app/src/pages/myNotes/styles.js
+++ b/note-app/src/pages/myNotes/styles.js
@@ -1,4 +1,4 @@
-export const Styles = {
+export const styles = {
   noteList: {
     width: '25vw',
     minWidth: '280px',

--- a/note-app/src/pages/myNotes/styles.js
+++ b/note-app/src/pages/myNotes/styles.js
@@ -18,5 +18,14 @@ export const styles = {
   pageBody: {
     display: 'flex',
     minHeight: '100vh',
-  }
+  },
+
+  editPanelWrapper: {
+    boxShadow: '#609BEB 0 0 7px 2px',
+    margin: '20px',
+    padding: '5px 25px',
+    borderRadius: '5px',
+    transition: 'box-shadow 0.3s',
+    backgroundColor: '#333333',
+  },
 };

--- a/note-app/src/utils/getNoteDescription.js
+++ b/note-app/src/utils/getNoteDescription.js
@@ -1,0 +1,10 @@
+import MAX_DESCRIPTION_LENGTH from "../config/constants/maxDescriptionLength";
+
+const getNoteDescription = (note) =>
+  note.description
+    ? note.description < MAX_DESCRIPTION_LENGTH
+      ? note.description
+      : note.description.substring(0, MAX_DESCRIPTION_LENGTH) + '...'
+    : '';
+
+export default getNoteDescription;

--- a/note-app/src/utils/getNoteDescription.js
+++ b/note-app/src/utils/getNoteDescription.js
@@ -1,4 +1,4 @@
-import MAX_DESCRIPTION_LENGTH from "../config/constants/maxDescriptionLength";
+import { MAX_DESCRIPTION_LENGTH } from "../config/constants";
 
 const getNoteDescription = (note) =>
   note.description


### PR DESCRIPTION
# Overview 
> The goal of the pr was to implement the process of notes editing and saving of changes locally in browser's local storage.  

# Changes  
> 1. Material-UI buttons (edit & delete) added to display-note-panel.  
> 1. Ant-design hidden inputs added to display-note-panel. Inputs are shown when user enter the editing mode.  
> 1. Material-UI buttons (apply & cancel) added to hidden edit panel.  
> 1. Implemented editing of notes, saving them to local storage of a browser and undoing changes.  

# How to test  
> Visit [note-app](https://wooz1ewu.github.io/ITechArt_Front-End/) in gh-pages.  
> 1. Click on a note you want to edit.  
> 1.1. Check if buttons displayed near the content of the note.  
> 2. Click on the edit button to enter the editing mode.  
> 2.1.  Check if edit mode was successfully turned on.
> 2.1.1. Check if edit inputs and buttons with the content of particular note are shown.  
> 2.1.2. Try to select another note and check if app blocks it or not.  
> 2.2. Change some content via provided inputs and click on apply to save changes locally or cancel to undo them.  
> 3. Refresh the page to make sure that changes are saved locally.  